### PR TITLE
feat: enhance layout and interactive sections

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,24 +1,47 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Header from './components/Header.jsx';
+import Hero from './components/Hero.jsx';
+import { SummitSection, NewsSection } from './components/Cards.jsx';
+import Gallery from './components/Gallery.jsx';
+import Videos from './components/Videos.jsx';
+import BackToTop from './components/BackToTop.jsx';
 
-// Main application component
+// Compose sections and handle intersection reveal
 export default function App() {
+  useEffect(() => {
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const elements = document.querySelectorAll('[data-reveal]');
+    if (reduce) {
+      elements.forEach(el => el.classList.add('reveal'));
+      return;
+    }
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('reveal');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+    elements.forEach(el => observer.observe(el));
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <>
       <a href="#main" className="skip-link">Skip to content</a>
       <Header />
-      <main id="main" className="container">
-        <section className="hero">
-          <h1>National Day Celebration</h1>
-          <p>React and Vite starter template.</p>
-        </section>
-        <section>
-          <p>Main content placeholder.</p>
-        </section>
+      <main id="main">
+        <Hero />
+        <SummitSection />
+        <NewsSection />
+        <Gallery />
+        <Videos />
       </main>
-      <footer className="footer">
-        <small>© 2025 National Day Demo</small>
+      <footer className="site-footer">
+        <p>© 2025 國慶籌備單位｜示意版面（靜態樣板）</p>
       </footer>
+      <BackToTop />
     </>
   );
 }

--- a/src/components/BackToTop.jsx
+++ b/src/components/BackToTop.jsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect } from 'react';
+
+// Scroll back-to-top round button
+export default function BackToTop() {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setShow(window.scrollY > 600);
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollTop = () => {
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+  };
+
+  return (
+    <button
+      id="backToTop"
+      className={`back-to-top${show ? ' show' : ''}`}
+      aria-label="Back to top"
+      onClick={scrollTop}
+    >
+      ↑
+    </button>
+  );
+}

--- a/src/components/Cards.jsx
+++ b/src/components/Cards.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import thumb from '../../assets/thumb1.svg';
+
+// Summit cards grid
+const summitItems = [
+  { title: '典禮流程', text: '預計於上午十點準時開始，敬請期待。' },
+  { title: '貴賓介紹', text: '國內外嘉賓雲集，共襄盛舉。' },
+  { title: '精彩表演', text: '樂舞展演，呈現多元文化之美。' }
+];
+
+export function SummitSection() {
+  return (
+    <section id="summit" className="summit">
+      <div className="container">
+        <h2><span className="accent">｜</span>國慶大會</h2>
+        <div className="grid">
+          {summitItems.map((item, i) => (
+            <article className="card" data-reveal key={i}>
+              <h3>{item.title}</h3>
+              <p>{item.text}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// Latest news wide card
+export function NewsSection() {
+  const item = {
+    chip: '9/4 15:00 開放',
+    title: '國慶活動報名即將開始',
+    text: '敬請期待，更多活動資訊將陸續公布。',
+    img: thumb,
+    link: '#'
+  };
+
+  return (
+    <section id="news" className="news">
+      <div className="container">
+        <h2><span className="accent">｜</span>最新消息</h2>
+        <article className="news-card" data-reveal>
+          <div className="news-info">
+            <div className="chip">{item.chip}</div>
+            <h3>{item.title}</h3>
+            <p>{item.text}</p>
+            <a href={item.link} className="btn primary">前往報名</a>
+          </div>
+          <img src={item.img} alt="活動預告縮圖" width="400" height="300" loading="lazy" />
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Gallery.jsx
+++ b/src/components/Gallery.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import photo1 from '../../assets/photo1.svg';
+import photo2 from '../../assets/photo2.svg';
+import photo3 from '../../assets/photo3.svg';
+
+// Horizontal scrollable photo gallery
+const images = [
+  { src: photo1, alt: '慶典照片一', width: 800, height: 600 },
+  { src: photo2, alt: '慶典照片二', width: 800, height: 600 },
+  { src: photo3, alt: '慶典照片三', width: 800, height: 600 }
+];
+
+export default function Gallery() {
+  return (
+    <section id="gallery" className="gallery">
+      <div className="container">
+        <h2><span className="accent">｜</span>相片錦集</h2>
+        <div className="scroll" tabIndex="0" data-reveal>
+          {images.map((img, i) => (
+            <img
+              key={i}
+              src={img.src}
+              alt={img.alt}
+              width={img.width}
+              height={img.height}
+              loading="lazy"
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,18 +1,42 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import logo from '../../assets/logo.svg';
 
-// Sticky site header with simple navigation
+// Sticky header with glassy backdrop and mobile menu
 export default function Header() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    // Lock body scroll when menu is open
+    document.body.classList.toggle('nav-open', open);
+  }, [open]);
+
+  const toggle = () => setOpen(!open);
+  const close = () => setOpen(false);
+
   return (
     <header className="site-header">
-      <div className="inner">
-        <span className="logo">National Day Site</span>
-        <nav aria-label="Primary">
-          <ul className="nav-list">
-            <li><a href="#">Home</a></li>
-            <li><a href="#">About</a></li>
-          </ul>
-        </nav>
-      </div>
+      <a href="#top" className="logo" aria-label="National Day logo">
+        <img src={logo} alt="National Day logo" width="120" height="40" />
+      </a>
+      <button
+        className="nav-toggle"
+        aria-label="Main menu"
+        aria-controls="siteNav"
+        aria-expanded={open}
+        onClick={toggle}
+      >
+        <span className="bar"></span>
+        <span className="bar"></span>
+        <span className="bar"></span>
+      </button>
+      <nav id="siteNav" className="site-nav" aria-label="Main menu">
+        <ul onClick={close}>
+          <li><a href="#summit">國慶大會</a></li>
+          <li><a href="#news">最新消息</a></li>
+          <li><a href="#gallery">相片錦集</a></li>
+          <li><a href="#videos">活動影音</a></li>
+        </ul>
+      </nav>
     </header>
   );
 }

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,42 @@
+import React, { useState, useEffect } from 'react';
+
+// Hero section with countdown and calls to action
+function getTimeLeft() {
+  const target = new Date('2025-10-10T10:00:00+08:00').getTime();
+  const now = Date.now();
+  const diff = target - now;
+  if (diff <= 0) return null;
+  const d = Math.floor(diff / 86400000);
+  const h = Math.floor((diff % 86400000) / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  return { d, h, m };
+}
+
+export default function Hero() {
+  const [time, setTime] = useState(getTimeLeft());
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(getTimeLeft()), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <section className="hero" id="top">
+      <div className="hero-inner" data-reveal>
+        <h1><span>中華民國</span><br /><span>生日快樂</span></h1>
+        <p className="sub">114年國慶大會｜台北</p>
+        {time && (
+          <div className="countdown" aria-label="Countdown">
+            <span><strong>{time.d}</strong><small>Days</small></span>
+            <span><strong>{time.h}</strong><small>Hours</small></span>
+            <span><strong>{time.m}</strong><small>Minutes</small></span>
+          </div>
+        )}
+        <div className="actions">
+          <a href="#news" className="btn primary">查看最新消息</a>
+          <a href="#summit" className="btn ghost">國慶大會資訊</a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Videos.jsx
+++ b/src/components/Videos.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+// Lazy-loaded YouTube videos with skeleton placeholders
+function Video({ id, title }) {
+  const [loaded, setLoaded] = useState(false);
+
+  const load = () => setLoaded(true);
+
+  const handleKey = (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      load();
+    }
+  };
+
+  return (
+    <div
+      className="video"
+      data-video={id}
+      tabIndex="0"
+      role="button"
+      aria-label={`播放${title}`}
+      onClick={load}
+      onKeyDown={handleKey}
+    >
+      {loaded ? (
+        <iframe
+          src={`https://www.youtube.com/embed/${id}?autoplay=1`}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          loading="lazy"
+        ></iframe>
+      ) : (
+        <div className="skeleton"></div>
+      )}
+    </div>
+  );
+}
+
+export default function Videos() {
+  const videos = [
+    { id: 'dQw4w9WgXcQ', title: '影片一' },
+    { id: 'kXYiU_JCYtU', title: '影片二' }
+  ];
+
+  return (
+    <section id="videos" className="videos">
+      <div className="container">
+        <h2><span className="accent">｜</span>活動影音</h2>
+        <div className="video-grid">
+          {videos.map((v) => (
+            <Video key={v.id} {...v} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,113 +1,114 @@
-/* Root variables for typography and spacing */
+/* Design tokens and global styles */
 :root {
-  --font-family: system-ui, -apple-system, 'Segoe UI', Arial, sans-serif;
-  --color-bg: #ffffff;
-  --color-text: #0a0f17;
-  --color-primary: #177FBF;
-  --space-1: 0.5rem;
-  --space-2: 1rem;
-  --space-3: 1.5rem;
-  --space-4: 2rem;
-  --max-width: 960px;
+  --brand-red:#E13A3A;
+  --brand-blue:#177FBF;
+  --brand-ink:#0B1B2B;
+  --gray-900:#0A0F17;
+  --gray-700:#2A3442;
+  --gray-500:#6B7686;
+  --gray-300:#D5DBE3;
+  --gray-100:#F3F6F9;
+  --white:#FFF;
+  --brush-gradient:
+    radial-gradient(circle at 0 0, var(--brand-red) 0, transparent 60%),
+    radial-gradient(circle at 100% 100%, var(--brand-blue) 0, transparent 60%);
+  --elev-1:0 2px 10px rgba(7,22,36,.06);
+  --elev-2:0 8px 24px rgba(7,22,36,.12);
+  --radius-lg:16px;
+  --radius-xl:24px;
+  --radius-pill:999px;
+  --fs-hero:clamp(28px,5vw,40px);
+  --fs-h2:clamp(20px,3.2vw,28px);
+  --fs-h3:clamp(16px,2.8vw,22px);
+  --fs-body:16px;
+  --fs-small:13px;
+  --space-1:8px;
+  --space-2:12px;
+  --space-3:16px;
+  --space-4:24px;
+  --space-5:32px;
+  --space-6:40px;
 }
+*,*::before,*::after{box-sizing:border-box;}
+html,body{margin:0;padding:0;}
+body{
+  font-family:"Noto Sans TC",system-ui,-apple-system,"Segoe UI",Arial,sans-serif;
+  font-size:var(--fs-body);
+  line-height:1.6;
+  color:var(--brand-ink);
+  background:var(--white);
+  background-image:var(--brush-gradient);
+  background-repeat:no-repeat;
+  background-size:150% 150%;
+  min-height:100vh;
+}
+img{max-width:100%;display:block;}
+a{text-decoration:none;color:inherit;}
+:focus-visible{outline:2px solid var(--brand-blue);outline-offset:2px;}
+.container{max-width:1100px;margin:0 auto;padding:0 var(--space-3);}
+.site-header{
+  position:sticky;top:0;z-index:1000;
+  display:flex;align-items:center;justify-content:space-between;
+  padding:var(--space-2) var(--space-3);
+  background:rgba(255,255,255,.75);
+  backdrop-filter:saturate(180%) blur(20px);
+}
+.nav-toggle{width:44px;height:44px;background:none;border:none;padding:0;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:6px;cursor:pointer;}
+.nav-toggle .bar{width:24px;height:2px;background:var(--brand-ink);transition:transform .3s,opacity .3s;}
+body.nav-open .nav-toggle .bar:nth-child(1){transform:translateY(8px) rotate(45deg);}
+body.nav-open .nav-toggle .bar:nth-child(2){opacity:0;}
+body.nav-open .nav-toggle .bar:nth-child(3){transform:translateY(-8px) rotate(-45deg);}
+#siteNav ul{list-style:none;margin:0;padding:0;}
+#siteNav a{display:block;padding:var(--space-2) 0;}
+@media(max-width:719px){
+  #siteNav{position:fixed;inset:0;display:none;flex-direction:column;align-items:flex-start;background:rgba(255,255,255,.97);padding:var(--space-6) var(--space-4);}
+  body.nav-open #siteNav{display:flex;}
+}
+@media(min-width:720px){
+  .nav-toggle{display:none;}
+  #siteNav{position:static;display:flex;}
+  #siteNav ul{display:flex;gap:var(--space-4);}
+  #siteNav a{padding:0;}
+}
+.hero{text-align:center;padding:var(--space-6) var(--space-3);}
+.hero h1{font-size:var(--fs-hero);line-height:1.2;margin:0;}
+.hero .sub{margin-top:var(--space-3);font-size:var(--fs-h3);color:var(--gray-700);}
+.countdown{display:flex;justify-content:center;gap:var(--space-4);margin-top:var(--space-4);}
+.countdown span{display:flex;flex-direction:column;align-items:center;}
+.countdown strong{font-size:var(--fs-h2);}
+.actions{margin-top:var(--space-5);display:flex;gap:var(--space-3);flex-wrap:wrap;justify-content:center;}
+.btn{padding:var(--space-2) var(--space-4);border-radius:var(--radius-pill);font-size:var(--fs-body);cursor:pointer;text-align:center;min-width:120px;}
+.btn.primary{background:linear-gradient(90deg,var(--brand-blue),var(--brand-red));color:var(--white);border:none;box-shadow:var(--elev-1);}
+.btn.ghost{border:1px solid var(--brand-blue);color:var(--brand-blue);background:transparent;}
+.btn:hover,.btn:focus-visible{box-shadow:var(--elev-2);}
+section{padding:var(--space-6) 0;}
+section h2{font-size:var(--fs-h2);margin:0 0 var(--space-4);display:flex;align-items:center;gap:var(--space-2);}
+.accent{color:var(--brand-red);}
+.grid{display:grid;gap:var(--space-4);}
+.card{background:var(--white);padding:var(--space-4);border-radius:var(--radius-lg);box-shadow:var(--elev-1);}
+.card h3{font-size:var(--fs-h3);margin-top:0;}
+@media(min-width:600px){.grid{grid-template-columns:repeat(2,1fr);}}
+@media(min-width:900px){.grid{grid-template-columns:repeat(3,1fr);}}
+.news-card{display:flex;flex-direction:column;background:var(--white);border-radius:var(--radius-lg);box-shadow:var(--elev-1);overflow:hidden;}
+.news-info{padding:var(--space-4);flex:1;}
+.news-card img{width:100%;height:100%;object-fit:cover;}
+.chip{display:inline-block;background:var(--brand-blue);color:var(--white);border-radius:var(--radius-pill);padding:0 var(--space-2);font-size:var(--fs-small);margin-bottom:var(--space-2);}
+@media(min-width:720px){.news-card{flex-direction:row;}.news-card img{max-width:50%;}}
+.gallery .scroll{display:flex;overflow-x:auto;gap:var(--space-3);scroll-snap-type:x mandatory;padding-bottom:var(--space-3);}
+.gallery img{flex:0 0 auto;width:80%;scroll-snap-align:start;border-radius:var(--radius-lg);box-shadow:var(--elev-1);}
+.video-grid{display:grid;gap:var(--space-4);}
+.video{position:relative;padding-top:56.25%;background:var(--gray-300);border-radius:var(--radius-lg);overflow:hidden;cursor:pointer;}
+.video iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0;}
+.skeleton{position:absolute;inset:0;background:linear-gradient(90deg,var(--gray-300),var(--gray-100),var(--gray-300));background-size:200% 100%;animation:shimmer 2s infinite;}
+@keyframes shimmer{0%{background-position:-200% 0;}100%{background-position:200% 0;}}
+@media(min-width:720px){.video-grid{grid-template-columns:repeat(2,1fr);}}
+.site-footer{text-align:center;padding:var(--space-6) var(--space-3);font-size:var(--fs-small);color:var(--gray-500);}
+.back-to-top{position:fixed;right:var(--space-4);bottom:var(--space-4);width:44px;height:44px;border:none;border-radius:50%;background:var(--brand-blue);color:var(--white);display:none;align-items:center;justify-content:center;box-shadow:var(--elev-1);cursor:pointer;}
+.back-to-top.show{display:flex;}
+[data-reveal]{opacity:0;transform:translateY(20px);transition:opacity .6s,transform .6s;}
+.reveal{opacity:1;transform:none;}
+@media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important;}}
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box;
-}
+.skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden;}
+.skip-link:focus{position:static;width:auto;height:auto;padding:var(--space-2);}
 
-body {
-  margin: 0;
-  font-family: var(--font-family);
-  line-height: 1.5;
-  color: var(--color-text);
-  background: var(--color-bg);
-}
-
-img,
-svg {
-  display: block;
-  max-width: 100%;
-}
-
-.container {
-  max-width: var(--max-width);
-  margin: 0 auto;
-  padding: 0 var(--space-2);
-}
-
-.site-header {
-  position: sticky;
-  top: 0;
-  background: var(--color-bg);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
-  z-index: 100;
-}
-
-.site-header .inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-2);
-  max-width: var(--max-width);
-  margin: 0 auto;
-}
-
-.nav-list {
-  display: flex;
-  gap: var(--space-2);
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.hero {
-  padding: var(--space-4) var(--space-2);
-  text-align: center;
-}
-
-.footer {
-  text-align: center;
-  padding: var(--space-3) var(--space-2);
-  font-size: 0.875rem;
-  color: #555;
-}
-
-.skip-link {
-  position: absolute;
-  left: -999px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}
-
-.skip-link:focus {
-  position: static;
-  width: auto;
-  height: auto;
-  margin: var(--space-2);
-}
-
-:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  * {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
-
-h1 {
-  font-size: clamp(1.75rem, 5vw, 2.5rem);
-  margin: 0 0 var(--space-2);
-}
-
-p {
-  margin: 0 0 var(--space-2);
-}


### PR DESCRIPTION
## Summary
- add design tokens and global styles for brush-themed layout
- implement sticky header, hero countdown, content sections, and gallery
- lazy load videos and provide back-to-top interaction

## Testing
- `npm run build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b71f808a88832494fd9e58d529dcab